### PR TITLE
Removed inner .fullscreen

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -21,7 +21,7 @@ function common_header($extra_headers=NULL, $TITLE = "Quality Assurance") {
         array("href" => "/pulls/",            "text" => "Github PRs"),
     );
     include __DIR__ . "/../shared/templates/header.inc";
-    echo '<section class="fullscreen">';
+    echo '<section class="mainscreen">';
 }
 
 function common_footer($JS = array()) {


### PR DESCRIPTION
The template already has a `.fullscreen`; this one is redundant. It should be `.mainscreen`.
