### PR TITLE
Fix non-existent --CREDIT-- tag to --CREDITS--

### DIFF
--- a/phpt_details.php
+++ b/phpt_details.php
@@ -91,7 +91,7 @@ run-tests.php, server-tests.php</p>
 Name Email<br/>
 [Event]</p>
 <p><b>Example 1 (snippet):</b><br/>
-<pre>--CREDIT--
+<pre>--CREDITS--
 Felipe Pena <felipe@php.net></pre>
 </p>
 <p><b>Example 1 (full):</b> <a href="sample_tests/sample001.php">sample001.phpt</a></p>

--- a/sample_tests/sample001.php
+++ b/sample_tests/sample001.php
@@ -17,7 +17,7 @@ Test filter_input() with GET and POST data.
 This test covers both valid and invalid usages of
 filter_input() with INPUT_GET and INPUT_POST data
 and several differnt filter sanitizers.
---CREDIT--
+--CREDITS--
 Felipe Pena &lt;felipe@php.net&gt;
 --INI--
 precision=14


### PR DESCRIPTION
Since PHP 7.3 custom tags are not allowed unless specially set in the main run-tests.php script.