### PR TITLE
Rename test001.expected.txt to test001.expected.data

### DIFF
--- a/phpt_details.php
+++ b/phpt_details.php
@@ -670,9 +670,9 @@ One of the EXPECT type sections is required.</p>
 run-tests.php</p>
 <p><b>Example 1 (snippet):</b><br/>
 <pre>--EXPECT_EXTERNAL--
-test001.expected.txt
+test001.expected.data
 </pre>
-<p><b>test001.expected.txt</b>
+<p><b>test001.expected.data</b>
 <pre>array(2) {
   [&quot;hello&quot;]=&gt;
   string(5) &quot;World&quot;


### PR DESCRIPTION
The *.txt files are ignored by .gitignore and testing system used by
PHP. It's a better and more logical practice to avoid tracking ignored
files, so this patch renames two occurrences of *.txt in examples to
*.data for convenience.