### PR TITLE
Refactor long array() syntax to short []

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -8,25 +8,25 @@ function common_header($extra_headers=NULL, $TITLE = "Quality Assurance") {
         $HEAD_RAND = join("\n", $extra_headers);
     }
     $SUBDOMAIN = "QA";
-    $CSS = array("/styles/qa.css");
-    $LINKS = array(
-        array("href" => "/projects.php",      "text" => "Goals"),
-        array("href" => "/rc.php",            "text" => "What is RC?"),
-        array("href" => "/howtohelp.php",     "text" => "Contributing"),
-        array("href" => "/handling-bugs.php", "text" => "Handling Reports"),
-        array("href" => "/reports/",          "text" => "Reports"),
-        array("href" => "/pulls/",            "text" => "Github PRs"),
-    );
+    $CSS = ["/styles/qa.css"];
+    $LINKS = [
+        ["href" => "/projects.php",      "text" => "Goals"],
+        ["href" => "/rc.php",            "text" => "What is RC?"],
+        ["href" => "/howtohelp.php",     "text" => "Contributing"],
+        ["href" => "/handling-bugs.php", "text" => "Handling Reports"],
+        ["href" => "/reports/",          "text" => "Reports"],
+        ["href" => "/pulls/",            "text" => "Github PRs"],
+    ];
     include __DIR__ . "/../shared/templates/header.inc";
     echo '<section class="mainscreen">';
 }
 
-function common_footer($JS = array()) {
+function common_footer($JS = []) {
     echo "</section>";
     include __DIR__ . "/../shared/templates/footer.inc";
 }
 
-function is_valid_php_version($version, $QA_RELEASES = array()) {
+function is_valid_php_version($version, $QA_RELEASES = []) {
 
 	if (isset($QA_RELEASES['reported']) && in_array($version, $QA_RELEASES['reported'])) {
 		return true;

--- a/include/release-qa.php
+++ b/include/release-qa.php
@@ -2,44 +2,44 @@
 
 /*
 What this file does:
-	- Generates the download links found at qa.php.net
-	- Determines which test results are emailed to news.php.net/php.qa.reports
-	- Defines $QA_RELEASES for internal and external (api.php) use, contains all qa related information for future PHP releases
+    - Generates the download links found at qa.php.net
+    - Determines which test results are emailed to news.php.net/php.qa.reports
+    - Defines $QA_RELEASES for internal and external (api.php) use, contains all qa related information for future PHP releases
 
 Documentation:
-	$QA_RELEASES documentation:
-		Configuration:
-		- Key is future PHP version number
-			- Example: If 5.3.6 is the latest stable release, then use 5.3.7 because 5.3.7-dev is our qa version
-			- Typically, this is the only part needing changed
-		- active (bool):
-			- It's active and being tested here
-			- Meaning, the version will be reported to the qa.reports list, and be linked at qa.php.net
-			- File extensions .tar.gz and .tar.bz2 are assumed to be available
-		- release (array):
-			- type: RC, alpha, and beta are examples (case should match filename case)
-			- version: 0 if no such release exists, otherwise an integer of the rc/alpha/beta number
-			- sha256_bz2: sha256 checksum of this downloadable .tar.bz2 file
-			- sha256_gz:  sha256 checksum of this downloadable .tar.gz file
-			- sha256_xz: sha256 checksum of this downloadble .xz file
-			- date: date of release e.g., 21 May 2011
-			- baseurl: base url of where these downloads are located
-			- Multiple checksums can be available, see the $QA_CHECKSUM_TYPES array below
-		Other variables within $QA_RELEASES are later defined including:
-			- reported: versions that make it to the qa.reports mailing list
-			- release: all current qa releases, including paths to dl urls (w/ sha256 info)
-			- dev_version: dev version
-			- $QA_RELEASES is made available at qa.php.net/api.php
+    $QA_RELEASES documentation:
+        Configuration:
+        - Key is future PHP version number
+            - Example: If 5.3.6 is the latest stable release, then use 5.3.7 because 5.3.7-dev is our qa version
+            - Typically, this is the only part needing changed
+        - active (bool):
+            - It's active and being tested here
+            - Meaning, the version will be reported to the qa.reports list, and be linked at qa.php.net
+            - File extensions .tar.gz and .tar.bz2 are assumed to be available
+        - release (array):
+            - type: RC, alpha, and beta are examples (case should match filename case)
+            - version: 0 if no such release exists, otherwise an integer of the rc/alpha/beta number
+            - sha256_bz2: sha256 checksum of this downloadable .tar.bz2 file
+            - sha256_gz:  sha256 checksum of this downloadable .tar.gz file
+            - sha256_xz: sha256 checksum of this downloadble .xz file
+            - date: date of release e.g., 21 May 2011
+            - baseurl: base url of where these downloads are located
+            - Multiple checksums can be available, see the $QA_CHECKSUM_TYPES array below
+        Other variables within $QA_RELEASES are later defined including:
+            - reported: versions that make it to the qa.reports mailing list
+            - release: all current qa releases, including paths to dl urls (w/ sha256 info)
+            - dev_version: dev version
+            - $QA_RELEASES is made available at qa.php.net/api.php
 
 TODO:
-	- Save all reports (on qa server) for all tests, categorize by PHP version (see buildtest-process.php)
-	- Consider storing rc downloads at one location, independent of release master
-	- Determine best way to handle rc baseurl, currently assumes .tar.gz/tar.bz2 will exist
-	- Determine if $QA_RELEASES is compatible with all current, and most future configurations
-	- Determine if $QA_RELEASES can be simplified
-	- Determine if alpha/beta options are desired
-	- Unify then create defaults for most settings
-	- Add option to allow current releases (e.g., retrieve current release info via daily cron, cache, check, configure ~ALLOW_CURRENT_RELEASES)
+    - Save all reports (on qa server) for all tests, categorize by PHP version (see buildtest-process.php)
+    - Consider storing rc downloads at one location, independent of release master
+    - Determine best way to handle rc baseurl, currently assumes .tar.gz/tar.bz2 will exist
+    - Determine if $QA_RELEASES is compatible with all current, and most future configurations
+    - Determine if $QA_RELEASES can be simplified
+    - Determine if alpha/beta options are desired
+    - Unify then create defaults for most settings
+    - Add option to allow current releases (e.g., retrieve current release info via daily cron, cache, check, configure ~ALLOW_CURRENT_RELEASES)
 */
 
 
@@ -47,71 +47,72 @@ TODO:
 /****** REMEMBER TO UPDATE "functions.php" WHEN BRANCHES CHANGE! ******/
 /**********************************************************************/
 
-$QA_RELEASES = array(
-	'5.6.39' => array(
-		'active'		=> true,
-		'release'		=> array(
-			'type'	    	=> 'RC',
-			'number'    	=> 0,
-			'sha256_bz2'	=> '',
-			'sha256_gz'	=> '',
-			'sha256_xz'	=> '',
-			'date'      	=> '05 January 2017',
-			'baseurl'   	=> 'http://downloads.php.net/tyrael/',
-		),
-	),
+$QA_RELEASES = [
+    '5.6.39' => [
+        'active'  => true,
+        'release' => [
+            'type'       => 'RC',
+            'number'     => 0,
+            'sha256_bz2' => '',
+            'sha256_gz'  => '',
+            'sha256_xz'  => '',
+            'date'       => '05 January 2017',
+            'baseurl'    => 'http://downloads.php.net/tyrael/',
+        ],
+    ],
 
-        '7.0.33' => array(
-                'active'                => true,
-                'release'               => array(
-                        'type'      	=> 'RC',
-                        'number'    	=> 0,
-                        'sha256_bz2'	=> '',
-                        'sha256_gz'     => '',
-                        'sha256_xz'     => '',
-                        'date'      	=> '07 December 2017',
-                        'baseurl'   	=> 'http://downloads.php.net/ab/',
-                ),
-        ),
+    '7.0.33' => [
+        'active'  => true,
+        'release' => [
+            'type'       => 'RC',
+            'number'     => 0,
+            'sha256_bz2' => '',
+            'sha256_gz'  => '',
+            'sha256_xz'  => '',
+            'date'       => '07 December 2017',
+            'baseurl'    => 'http://downloads.php.net/ab/',
+        ],
+    ],
 
-        '7.1.24' => array(
-                'active'                => true,
-                'release'		=> array(
-                        'type'          => 'RC',
-                        'number'        => 1,
-                        'sha256_bz2'    => 'ef53c6c5e4124a943bbf4bc5db40fcce1ece6d97fb8c623a6ee9f32499c348cc',
-                        'sha256_gz'     => '35fb2ad8279bbb26810d32bc71d78f55482dd6b3e2f401b46c155ee80a235cff',
-                        'sha256_xz'     => '994185b8b395a3f0448364999e72a7fe42c14daa978ba6a6a446a8039dad10a8',
-                        'date'          => '25 Oct 2018',
-                        'baseurl'       => 'http://downloads.php.net/~remi/',
-                ),
-		),
+    '7.1.24' => [
+        'active'  => true,
+        'release' => [
+            'type'       => 'RC',
+            'number'     => 1,
+            'sha256_bz2' => 'ef53c6c5e4124a943bbf4bc5db40fcce1ece6d97fb8c623a6ee9f32499c348cc',
+            'sha256_gz'  => '35fb2ad8279bbb26810d32bc71d78f55482dd6b3e2f401b46c155ee80a235cff',
+            'sha256_xz'  => '994185b8b395a3f0448364999e72a7fe42c14daa978ba6a6a446a8039dad10a8',
+            'date'       => '25 Oct 2018',
+            'baseurl'    => 'http://downloads.php.net/~remi/',
+        ],
+    ],
 
-        '7.2.12' => array(
-                'active'                => true,
-                'release'		=> array(
-                        'type'          => 'RC',
-                        'number'        => 1,
-                        'sha256_bz2'    => '59bbcd35e576be8838c588c5a0d17b4b9886e89355ba168bf525a0066eddebca',
-                        'sha256_gz'     => 'b281ab7f286f310d35ffb5b72b88b04c06918180009987769d9d4c6dc906c7f8',
-                        'sha256_xz'     => 'cbc000432efea35f323d4b8edaae5633e44fa2a0a87f56293d12afe72416d8b1',
-                        'date'          => '25 Oct 2018',
-                        'baseurl'       => 'https://downloads.php.net/~remi/',
-                ),
-        ),
-		'7.3.0' => array(
-            'active'                => true,
-            'release'		=> array(
-                    'type'          => 'RC',
-                    'number'        => 4,
-                    'sha256_bz2'    => 'afd973238a9dd3286ab01a46c859409c20176da3a431a78c8db94a5c5391e90c',
-                    'sha256_gz'     => '22ad2fb8e7148de8d618f773121e14abd095f22dc7b5ac21991daed45c265099',
-                    'sha256_xz'     => '11582176003e0e8ca06dbdebab0921d539cab2ad795c0d90f146977859e21c26',
-                    'date'          => '25 Oct 2018',
-                    'baseurl'       => 'https://downloads.php.net/~cmb/',
-            ),
-		),
-);
+    '7.2.12' => [
+        'active'  => true,
+        'release' => [
+            'type'       => 'RC',
+            'number'     => 1,
+            'sha256_bz2' => '59bbcd35e576be8838c588c5a0d17b4b9886e89355ba168bf525a0066eddebca',
+            'sha256_gz'  => 'b281ab7f286f310d35ffb5b72b88b04c06918180009987769d9d4c6dc906c7f8',
+            'sha256_xz'  => 'cbc000432efea35f323d4b8edaae5633e44fa2a0a87f56293d12afe72416d8b1',
+            'date'       => '25 Oct 2018',
+            'baseurl'    => 'https://downloads.php.net/~remi/',
+        ],
+    ],
+
+    '7.3.0' => [
+        'active'  => true,
+        'release' => [
+            'type'       => 'RC',
+            'number'     => 4,
+            'sha256_bz2' => 'afd973238a9dd3286ab01a46c859409c20176da3a431a78c8db94a5c5391e90c',
+            'sha256_gz'  => '22ad2fb8e7148de8d618f773121e14abd095f22dc7b5ac21991daed45c265099',
+            'sha256_xz'  => '11582176003e0e8ca06dbdebab0921d539cab2ad795c0d90f146977859e21c26',
+            'date'       => '25 Oct 2018',
+            'baseurl'    => 'https://downloads.php.net/~cmb/',
+        ],
+    ],
+];
 
 /*** End Configuration *******************************************************************/
 
@@ -122,64 +123,64 @@ $QA_RELEASES = array(
 // For example, if SHA512 were to be supported, the following indices would have to be added:
 //
 // 'sha512_bz2' => 'xxx',
-// 'sha512_gz'	=> 'xxx',
-// 'sha512_xz'	=> 'xxx',
-$QA_CHECKSUM_TYPES = [ 'sha256' ];
+// 'sha512_gz'  => 'xxx',
+// 'sha512_xz'  => 'xxx',
+$QA_CHECKSUM_TYPES = ['sha256'];
 
 // $QA_RELEASES eventually contains just about everything, also for external use
 // release  : These are encouraged for use (e.g., linked at qa.php.net)
 // reported : These are allowed to report @ the php.qa.reports mailing list
 
 (function(&$QA_RELEASES) use ($QA_CHECKSUM_TYPES) {
-	foreach ($QA_RELEASES as $pversion => $info) {
+    foreach ($QA_RELEASES as $pversion => $info) {
 
-		if (isset($info['active']) && $info['active']) {
+        if (isset($info['active']) && $info['active']) {
 
-			// Allow -dev versions of all active types
-			// Example: 5.3.6-dev
-			$QA_RELEASES['reported'][] = "{$pversion}-dev";
-			$QA_RELEASES[$pversion]['dev_version'] = "{$pversion}-dev";
+            // Allow -dev versions of all active types
+            // Example: 5.3.6-dev
+            $QA_RELEASES['reported'][] = "{$pversion}-dev";
+            $QA_RELEASES[$pversion]['dev_version'] = "{$pversion}-dev";
 
-			// Allow -dev version of upcoming qa releases (rc/alpha/beta)
-			// @todo confirm this php version format for all dev versions
-			if ((int)$info['release']['number'] > 0) {
-				$QA_RELEASES['reported'][] = "{$pversion}{$info['release']['type']}{$info['release']['number']}";
-				if (!empty($info['release']['baseurl'])) {
+            // Allow -dev version of upcoming qa releases (rc/alpha/beta)
+            // @todo confirm this php version format for all dev versions
+            if ((int)$info['release']['number'] > 0) {
+                $QA_RELEASES['reported'][] = "{$pversion}{$info['release']['type']}{$info['release']['number']}";
+                if (!empty($info['release']['baseurl'])) {
 
-					// php.net filename format for qa releases
-					// example: php-5.3.0RC2
-					$fn_base = 'php-' . $pversion . $info['release']['type'] . $info['release']['number'];
+                    // php.net filename format for qa releases
+                    // example: php-5.3.0RC2
+                    $fn_base = 'php-' . $pversion . $info['release']['type'] . $info['release']['number'];
 
-					$QA_RELEASES[$pversion]['release']['version'] = $pversion . $info['release']['type'] . $info['release']['number'];
-					foreach ([ 'bz2', 'gz', 'xz' ] as $file_type) {
-						foreach ($QA_CHECKSUM_TYPES as $algo) {
-							if (isset($info['release'][$algo . '_' . $file_type])) {
-								$QA_RELEASES[$pversion]['release']['files'][$file_type][$algo] = $info['release'][$algo . '_' . $file_type];
-							}
-						}
-						if (!empty($QA_RELEASES[$pversion]['release']['files'][$file_type])) {
-							$QA_RELEASES[$pversion]['release']['files'][$file_type]['path']= $info['release']['baseurl'] . $fn_base . '.tar.' . $file_type;
-						}
-					}
+                    $QA_RELEASES[$pversion]['release']['version'] = $pversion . $info['release']['type'] . $info['release']['number'];
+                    foreach ([ 'bz2', 'gz', 'xz' ] as $file_type) {
+                        foreach ($QA_CHECKSUM_TYPES as $algo) {
+                            if (isset($info['release'][$algo . '_' . $file_type])) {
+                                $QA_RELEASES[$pversion]['release']['files'][$file_type][$algo] = $info['release'][$algo . '_' . $file_type];
+                            }
+                        }
+                        if (!empty($QA_RELEASES[$pversion]['release']['files'][$file_type])) {
+                            $QA_RELEASES[$pversion]['release']['files'][$file_type]['path']= $info['release']['baseurl'] . $fn_base . '.tar.' . $file_type;
+                        }
+                    }
 
-					if (empty($QA_RELEASES[$pversion]['release']['files'])) {
-						$QA_RELEASES[$pversion]['release']['enabled'] = false;
-					}
-				}
-			} else {
-				$QA_RELEASES[$pversion]['release']['enabled'] = false;
-			}
+                    if (empty($QA_RELEASES[$pversion]['release']['files'])) {
+                        $QA_RELEASES[$pversion]['release']['enabled'] = false;
+                    }
+                }
+            } else {
+                $QA_RELEASES[$pversion]['release']['enabled'] = false;
+            }
 
-		}
-	}
+        }
+    }
 
-	// Sorted information for later use
-	// @todo need these?
-	// $QA_RELEASES['releases']   : All current versions with active qa releases
-	foreach ($QA_RELEASES as $pversion => $info) {
-		if (isset($info['active']) && $info['active'] && !empty($info['release']['number'])) {
-			$QA_RELEASES['releases'][$pversion] = $info['release'];
-		}
-	}
+    // Sorted information for later use
+    // @todo need these?
+    // $QA_RELEASES['releases']   : All current versions with active qa releases
+    foreach ($QA_RELEASES as $pversion => $info) {
+        if (isset($info['active']) && $info['active'] && !empty($info['release']['number'])) {
+            $QA_RELEASES['releases'][$pversion] = $info['release'];
+        }
+    }
 
 })($QA_RELEASES);

--- a/pulls/api.php
+++ b/pulls/api.php
@@ -1,5 +1,5 @@
 <?php
-$errors = array();
+$errors = [];
 require('./config.php');
 define('USER_AGENT', 'PHP Pull Request Admin (http://qa.php.net/pulls php-qa@lists.php.net)');
 
@@ -16,20 +16,20 @@ function verify_password($user, $pass)
     global $errors;
 
     $post = http_build_query(
-            array(
+            [
                     'token' => getenv('AUTH_TOKEN'),
                     'username' => $user,
                     'password' => $pass,
-            )
+            ]
     );
 
-    $opts = array(
+    $opts = [
             'method'        => 'POST',
             'header'        => 'Content-type: application/x-www-form-urlencoded',
             'content'       => $post,
-    );
+    ];
 
-    $ctx = stream_context_create(array('http' => $opts));
+    $ctx = stream_context_create(['http' => $opts]);
 
     $s = @file_get_contents('https://master.php.net/fetch/cvsauth.php', false, $ctx);
 
@@ -63,7 +63,7 @@ function do_http_request($url, $opts)
 	// IMPORTANT $opts might be logged. Make sure token is removed from log!
 	$opts['header'] = 'Authorization: token '.GITHUB_TOKEN;
 
-	$ctxt = stream_context_create(array('http' => $opts));
+	$ctxt = stream_context_create(['http' => $opts]);
 
 	$old_track_errors = ini_get('track_errors');
 	ini_set('track_errors', true);
@@ -73,12 +73,12 @@ function do_http_request($url, $opts)
 	if (isset($_SESSION['debug']['requests'])) {
 		// The token shall not be leaked!
 		$opts['header'] = 'Authorization: token (secret)';
-		$_SESSION['debug']['requests'][] = array(
+		$_SESSION['debug']['requests'][] = [
 			'url' => $url,
 			'opts'=> $opts,
 			'headers' => $http_response_header,
 			'response' => $s
-		);
+		];
 	}
 
 	if (!$s) {
@@ -93,25 +93,25 @@ function ghpostcomment($pull, $comment)
 {
 	global $errors;
 
-	$post = json_encode(array("body" => "**Comment on behalf of $_SESSION[user] at php.net:**\n\n$comment"));
+	$post = json_encode(["body" => "**Comment on behalf of $_SESSION[user] at php.net:**\n\n$comment"]);
 
 
-	$opts = array(
+	$opts = [
 		'method'        => 'POST',
 		'content'       => $post,
-	);
+	];
 
 	return (bool)do_http_request($pull->_links->comments->href, $opts);
 }
 
 function ghchangestate($pull, $state)
 {
-	$content = json_encode(array("state" => $state));
+	$content = json_encode(["state" => $state]);
 
-	$opts = array(
+	$opts = [
 		'method'  => 'PATCH',
 		'content' => $content
-	);
+	];
 
 	return (bool)do_http_request($pull->_links->self->href, $opts);
 }
@@ -122,10 +122,10 @@ function ghsetlabels($pull, $labels)
 		return true;
 	}
 
-	$opts = array(
+	$opts = [
 		'method'  => 'PUT',
 		'content' => json_encode($labels),
-	);
+	];
 
 	$url = $pull->issue_url . "/labels";
 
@@ -139,25 +139,25 @@ function login()
 	$func = DEV ? 'verify_password_DEV' : 'verify_password';
 	if ($func($_POST['user'], $_POST['pass'])) {
 		$_SESSION['user'] = $_POST['user'];
-		die(json_encode(array('success' => true, 'user' => $_POST['user'])));
+		die(json_encode(['success' => true, 'user' => $_POST['user']]));
 	} else {
 		header('HTTP/1.0 401 Unauthorized');
 		$_SESSION['user'] = false;
-		die(json_encode(array('success' => false, 'errors' => $errors)));
+		die(json_encode(['success' => false, 'errors' => $errors]));
 	}
 }
 
 function logout()
 {
 	session_destroy();
-	die(json_encode(array('success' => true)));
+	die(json_encode(['success' => true]));
 }
 
 function loggedin()
 {
-	$result = array(
+	$result = [
 		'success' => !empty($_SESSION['user'])
-	);
+	];
 	if (!empty($_SESSION['user'])) {
 		$result['user'] = $_SESSION['user'];
 	}
@@ -170,50 +170,50 @@ function ghupdate()
 
 	if (empty($_SESSION['user'])) {
 		header('HTTP/1.0 401 Unauthorized');
-		die(json_encode(array('success' => false, 'errors' => array('Unauthorized'))));
+		die(json_encode(['success' => false, 'errors' => ['Unauthorized']]));
 	}
 
 	if (empty($_POST['repo'])) {
 		header('HTTP/1.0 400 Bad Request');
-		die(json_encode(array('success' => false, 'errors' => array("No repo provided"))));
+		die(json_encode(['success' => false, 'errors' => ["No repo provided"]]));
 	}
 
 	if (empty($_POST['id']) || !is_numeric($_POST['id'])) {
 		header('HTTP/1.0 400 Bad Request');
-		die(json_encode(array('success' => false, 'errors' => array("No or inalid id provided"))));
+		die(json_encode(['success' => false, 'errors' => ["No or inalid id provided"]]));
 	}
 
 	if (empty($_POST['comment']) || !($comment = trim($_POST['comment']))) {
 		header('HTTP/1.0 400 Bad Request');
-		die(json_encode(array('success' => false, 'errors' => array("No comment provided"))));
+		die(json_encode(['success' => false, 'errors' => ["No comment provided"]]));
 	}
 
-	if (!empty($_POST['state']) && !in_array($_POST['state'], array('open', 'closed'))) {
+	if (!empty($_POST['state']) && !in_array($_POST['state'], ['open', 'closed'])) {
 		header('HTTP/1.0 400 Bad Request');
-		die(json_encode(array('success' => false, 'errors' => array("Invalid state"))));
+		die(json_encode(['success' => false, 'errors' => ["Invalid state"]]));
 	}
 
 	$url = GITHUB_BASEURL.'repos/'.GITHUB_ORG.'/'.urlencode($_POST['repo']).'/pulls/'.$_POST['id'];
-	$ctxt = stream_context_create(array(
-		'http' => array(
+	$ctxt = stream_context_create([
+		'http' => [
 			'ignore_errors' => '1',
 			'user_agent' => USER_AGENT,
-		)
-	));
+		]
+	]);
 	$pull_raw = @file_get_contents($url, false, $ctxt);
 	$pull = $pull_raw ? json_decode($pull_raw) : false;
 	if (!is_object($pull) || empty($pull->state)) {
 		header('HTTP/1.0 400 Bad Request');
 		if (isset($_SESSION['debug']['requests'])) {
-			$_SESSION['debug']['requests'][] = array(
+			$_SESSION['debug']['requests'][] = [
 				"message" => "Request to GitHub failed",
 				"url" => $url,
 				"http response" => $http_response_header,
 				"response" => $pull_raw,
 				"json error" => json_last_error()
-			);
+			];
 		}
-		die(json_encode(array('success' => false, 'errors' => array("Failed to get data from GitHub", "http" => $http_response_header, "json" => json_last_error()))));
+		die(json_encode(['success' => false, 'errors' => ["Failed to get data from GitHub", "http" => $http_response_header, "json" => json_last_error()]]));
 	}
 
 	$comment = @get_magic_quotes_gpc() ? stripslashes($_POST['comment']) : $_POST['comment'];
@@ -221,14 +221,14 @@ function ghupdate()
 	if (!ghpostcomment($pull, $comment)) {
 		header('500 Internal Server Error');
 		$errors[] = "Failed to add comment on GitHub";
-		die(json_encode(array('success' => false, 'errors' => $errors)));
+		die(json_encode(['success' => false, 'errors' => $errors]));
 	}
 
 	if (!empty($_POST['state'])) {
 		if (!ghchangestate($pull, $_POST['state'])) {
 			header('500 Internal Server Error');
 			$errors[] = "Failed to set new state";
-			die(json_encode(array('success' => false, 'errors' => $errors)));
+			die(json_encode(['success' => false, 'errors' => $errors]));
 		}
 	}
 
@@ -236,16 +236,16 @@ function ghupdate()
 		if (!ghsetlabels($pull, $_POST['labels'])) {
 			header('500 Internal Server Error');
 			$errors[] = "Failed to set labels";
-			die(json_encode(array('success' => false, 'errors' => $errors)));
+			die(json_encode(['success' => false, 'errors' => $errors]));
 		}
 	}
 
-	die(json_encode(array('success' => true)));
+	die(json_encode(['success' => true]));
 }
 
 function requestlog() {
 	if (!isset($_SESSION['debug']['requests'])) {
-		$_SESSION['debug']['requests'] = array();
+		$_SESSION['debug']['requests'] = [];
 	}
 
 	header('Content-Type: text/plain');
@@ -256,17 +256,17 @@ function requestlog() {
 header('Content-Type: application/json');
 session_start();
 
-$accepted_actions = array(
+$accepted_actions = [
 	'login',
 	'logout',
 	'loggedin',
 	'ghupdate',
 	'requestlog'
-);
+];
 if (isset($_REQUEST['action']) && in_array($_REQUEST['action'], $accepted_actions)) {
 	$action = $_REQUEST['action'];
 	$action();
 } else {
 	header('HTTP/1.0 400 Bad Request');
-	die(json_encode(array('success' => false, 'errors' => array("Unknown method"))));
+	die(json_encode(['success' => false, 'errors' => ["Unknown method"]]));
 }

--- a/pulls/index.php
+++ b/pulls/index.php
@@ -158,13 +158,13 @@ if (!constant('GITHUB_TOKEN')) {
 
   <link href="jquery-ui.css" rel="stylesheet" type="text/css"/>
 <?php
-$JS = array(
+$JS = [
     "//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js",
     "//qa.php.net/pulls/jsrender.js",
     "//qa.php.net/pulls/pullrequests.js",
     "//qa.php.net/pulls/jquery.ba-bbq.min.js",
     "//qa.php.net/pulls/Markdown.Converter.js",
     "//qa.php.net/pulls/Markdown.Sanitizer.js",
-);
+];
 
 common_footer($JS);

--- a/reports/convert.php
+++ b/reports/convert.php
@@ -3,7 +3,7 @@
 if (file_exists('db/update_20120407.lock')) {
     exit('SQLite files has already been updated with new scheme (date 2012-04-07)');
 }
-        $queriesCreate = array (
+        $queriesCreate = [
             'dropexpected' => 'DROP TABLE IF exists expectedfail',
             'expectedfail' => 'CREATE TABLE IF NOT EXISTS expectedfail (
                   `id` integer PRIMARY KEY AUTOINCREMENT,
@@ -15,7 +15,7 @@ if (file_exists('db/update_20120407.lock')) {
                   `id_report` bigint(20) NOT NULL,
                   `test_name` varchar(128) NOT NULL
                 )',
-        );
+        ];
 header('Content-Type: text/plain');
 
 $d = dir('db');

--- a/reports/details.php
+++ b/reports/details.php
@@ -44,7 +44,7 @@ $query = 'SELECT reports.* FROM failed JOIN reports ON reports.id=failed.id_repo
 $stmt = $database->prepare($query);
 $stmt->bindValue(':signature', hex2bin($signature), SQLITE3_BLOB);
 $q = $stmt->execute();
-$reportsArray = array();
+$reportsArray = [];
 while ($tab = $q->fetchArray(SQLITE3_ASSOC)) {
     $reportsArray[$tab['id']] = $tab;
 }
@@ -59,7 +59,7 @@ list($testName) = $tab->fetchArray(SQLITE3_NUM);
 $database->close();
 
 $TITLE = "Report details";
-common_header(array('<meta name="robots" content="noindex">'));
+common_header(['<meta name="robots" content="noindex">']);
 ?>
 <script src="sorttable.js"></script>
 <div style="margin:10px">

--- a/reports/parse_ciqa.php
+++ b/reports/parse_ciqa.php
@@ -26,14 +26,14 @@ $rss = new SimpleXMLElement('http://ci.qa.php.net/rssAll', 0, true);
 
 // get latest build done
 if (!file_exists('db/ciqaversion.txt')) {
-    $latestVersion = array();
+    $latestVersion = [];
 } else {
     $latestVersion = unserialize(file_get_contents('db/ciqaversion.txt'));
 }
-$newLatestVersion = array(); // this array will erase latestVersion at the end of the next loop
+$newLatestVersion = []; // this array will erase latestVersion at the end of the next loop
 
 // we grab builds in this array
-$buildArray = array();
+$buildArray = [];
 
 foreach ($rss->entry as $test) {
     $linkAttr = $test->link->attributes();
@@ -48,13 +48,13 @@ foreach ($rss->entry as $test) {
     }
 
 
-    $elem = array(
+    $elem = [
         'id' => (int) $pos[3],
         'date' => strtotime($test->updated),
         'version' => $pos[1],
         'archi' => $pos[2],
         'url'  => $pos[0],
-    );
+    ];
     //keep it !
     $buildArray[] = $elem;
 
@@ -75,8 +75,8 @@ echo "We have ".count($buildArray)." builds to parse ... \n\n";
  * we do not add each report to QA (sqlite files will be too big)
  * We choose to pack them based on version parsed
  */
-$failingTests = array();
-$successfulTests = array();
+$failingTests = [];
+$successfulTests = [];
 
 foreach ($buildArray as $build) {
     printf(" * #%s (%5s) - %-30s ", $build['id'], $build['version'], $build['archi']);
@@ -138,7 +138,7 @@ require '../include/functions.php';
 foreach ($successfulTests as $version => $successTests) {
     echo "* ".$version." ";
 
-    $firstArray = array ();
+    $firstArray = [];
 
     // determine status (success or failure ?)
     if (count($failingTests[$version]) == 0)
@@ -173,14 +173,14 @@ foreach ($successfulTests as $version => $successTests) {
     $firstArray['failedTest'] = array_keys($failingTests[$version]);
 
     // expected Failed Test
-    $firstArray['expectedFailedTest'] = array();
+    $firstArray['expectedFailedTest'] = [];
 
     // success
     $firstArray['succeededTest'] = array_keys($successTests);
 
     // tests
     foreach ($failingTests[$version] as $test => $diff) {
-        $firstArray['tests'][$test] = array ('output' => '', 'diff' => str_replace("\n", "\x0d\n", $diff));
+        $firstArray['tests'][$test] = ['output' => '', 'diff' => str_replace("\n", "\x0d\n", $diff)];
     }
 
     $status = insertToDb_phpmaketest($firstArray, $QA_RELEASES);

--- a/reports/parserfunc.php
+++ b/reports/parserfunc.php
@@ -36,7 +36,7 @@
  * @param array releases we accept (so that we don't accept a report that claims to be PHP 8.1 for example)
  * @return boolean success or not (for the moment, error leads to a call to 'exit;' ... not good I know)
  */
-function insertToDb_phpmaketest($array, $QA_RELEASES = array())
+function insertToDb_phpmaketest($array, $QA_RELEASES = [])
 {
     if (!is_array($array)) {
         // impossible to fetch data. We'll record this error later ...
@@ -57,7 +57,7 @@ function insertToDb_phpmaketest($array, $QA_RELEASES = array())
 
         $dbFile = __DIR__.'/db/'.$array['version'].'.sqlite';
 
-        $queriesCreate = array (
+        $queriesCreate = [
             'failed' => 'CREATE TABLE IF NOT EXISTS failed (
                   `id` integer PRIMARY KEY AUTOINCREMENT,
                   `id_report` bigint(20) NOT NULL,
@@ -87,7 +87,7 @@ function insertToDb_phpmaketest($array, $QA_RELEASES = array())
                   phpinfo STRING NOT NULL,
                   user_email varchar(64) default null
             )',
-        );
+        ];
 
 
         if (!file_exists($dbFile)) {
@@ -105,7 +105,7 @@ function insertToDb_phpmaketest($array, $QA_RELEASES = array())
         $dbi = new SQLite3($dbFile, SQLITE3_OPEN_READWRITE) or exit('cannot open DB to record results');
 
         // handle tests with no success
-        if (!isset($array['succeededTest'])) $array['succeededTest'] = array();
+        if (!isset($array['succeededTest'])) $array['succeededTest'] = [];
 
         $query = <<<'SQL'
 INSERT INTO `reports` (
@@ -220,11 +220,11 @@ SQL;
  */
 function parse_phpmaketest($version, $status=null, $file)
 {
-    $extract = array();
+    $extract = [];
 
     $extract['version'] = $version;
 
-    if (in_array($status, array('failed', 'success', 'unknown')))
+    if (in_array($status, ['failed', 'success', 'unknown']))
         $extract['status'] = $status;
     else
         $extract['status'] = null;
@@ -233,10 +233,10 @@ function parse_phpmaketest($version, $status=null, $file)
 
     $extract['date'] = time();
 
-    $extract['expectedFailedTest'] = array();
-    $extract['failedTest'] = array();
-    $extract['outputsRaw'] = array();
-    $extract['tests']      = array();
+    $extract['expectedFailedTest'] = [];
+    $extract['failedTest'] = [];
+    $extract['outputsRaw'] = [];
+    $extract['tests']      = [];
     $extract['phpinfo']    = '';
     $extract['buildEnvironment']    = '';
 
@@ -323,7 +323,7 @@ function parse_phpmaketest($version, $status=null, $file)
     // 2nd loop on outputs
     foreach ($extract['outputsRaw'] as $name => $output) {
         $name = substr($name, strlen($prefix));
-        $extract['tests'][$name] = array ('output' => '', 'diff' => '');
+        $extract['tests'][$name] = ['output' => '', 'diff' => ''];
         $outputTest = '';
         $diff = '';
         $startDiff = false;

--- a/reports/reportsfunctions.php
+++ b/reports/reportsfunctions.php
@@ -85,9 +85,9 @@ class specificVersionFilterIterator extends WhitelistedFilterIterator
 
     public function __construct(Traversable $inner, $keyword)
     {
-        parent::__construct($inner, array());
+        parent::__construct($inner, []);
         if (!is_array($keyword))
-            $this->keyword = array($keyword);
+            $this->keyword = [$keyword];
         else
             $this->keyword = $keyword;
     }
@@ -131,11 +131,11 @@ function get_summary_data($mode = QA_REPORT_FILTER_ALL)
 {
     global $QA_RELEASES;
 
-    $data = array();
+    $data = [];
     $it = new QaReportIterator(new DirectoryIterator(__DIR__.'/db/'));
 
     // temp fix
-    $it = new specificVersionFilterIterator($it, array('5.3.99-dev', '5.4.0-dev'));
+    $it = new specificVersionFilterIterator($it, ['5.3.99-dev', '5.4.0-dev']);
 
     if ($mode & QA_REPORT_FILTER_ALPHA) {
         $it = new keywordFilterIterator($it, 'alpha', $QA_RELEASES['reported']);

--- a/reports/test-insert.php
+++ b/reports/test-insert.php
@@ -139,7 +139,7 @@ if (!isset($sqlReport['id'])) die('cannot make more tests');
 
 $query = 'SELECT * FROM failed WHERE id_report = '.$sqlReport['id'];
 $q = $database->query($query);
-$sqlFailed = array();
+$sqlFailed = [];
 while ($tab = $q->fetchArray(SQLITE3_ASSOC)) {
     $sqlFailed[$tab['test_name']] = $tab;
 }

--- a/reports/viewreports.php
+++ b/reports/viewreports.php
@@ -46,7 +46,7 @@ GROUP BY diff ORDER BY COUNT(*) desc';
 $stmt = $database->prepare($query);
 $stmt->bindValue(':test_name', $testName, SQLITE3_TEXT);
 $q = $stmt->execute();
-$allDiffArray = array();
+$allDiffArray = [];
 $sumCount = 0;
 while ($tab = $q->fetchArray(SQLITE3_ASSOC)) {
     $allDiffArray[] = $tab;


### PR DESCRIPTION
Since site is using PHP 5.4+ already, the longer `array()` syntax can be refactored to shorter `[]`.