### PR TITLE
Suggest the usage of ssh git URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This repo depends on https://git.php.net/?p=web/shared.git;a=summary
 Please clone that repo into this websites root directory.
 
 ```bash
-git clone git://git.php.net/web/qa.git qa
+git clone git@git.php.net:/web/qa.git qa
 cd qa
-git clone git://git.php.net/web/shared.git shared
+git clone git@git.php.net:/web/shared.git shared
 cp pulls/config.php.in pulls/config.php
 php -S localhost:8080
 ```


### PR DESCRIPTION
Using the previous ones, it was causing some problems with `git push`:

```
fatal: remote error: access denied or repository not exported: /web/qa.git
```